### PR TITLE
Adding an ignore white space option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ source /path/to/zlong_alert.zsh
 
 ## Configuration
 
-There are 3 variables you can set that will alter the behavior this script.
+There are 4 variables you can set that will alter the behavior this script.
 
 - `zlong_duration` (default: `15`): number of seconds that is considered a long duration.
 - `zlong_ignore_cmds` (default: `"vim ssh"`): commands to ignore.
 - `zlong_use_notify_send` (default: `true`): whether to use `notify-send`.
+- `zlong_ignorespace` (default: `false`): whether to ignore commands with a leading space
 
 For example, adding the following anywhere in your `.zshrc`
 ```bash

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -40,7 +40,7 @@ zlong_alert_pre() {
 zlong_alert_post() {
     local duration=$(($EPOCHSECONDS - $zlong_timestamp))
     local lasted_long=$(($duration - $zlong_duration))
-    local cmd_head=$(echo $zlong_last_cmd | cut -d ' ' -f 1)
+    local cmd_head=$(echo $zlong_last_cmd | awk '{printf $1}')
     if [[ $lasted_long -gt 0 && ! -z $zlong_last_cmd && ! $zlong_ignore_cmds =~ $cmd_head ]]; then
         zlong_alert_func $zlong_last_cmd duration
     fi

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -43,8 +43,6 @@ zlong_alert_pre() {
         zlong_last_cmd=''
         zlong_timestamp=0
     else
-        # clean up white space so the notify output is nice
-        zlong_last_cmd="$(echo "$1" | sed -e 's|^\s\+||' -e 's|\s\s\+|\s|')"
         zlong_timestamp=$EPOCHSECONDS
     fi
 

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -38,7 +38,7 @@ zlong_alert_func() {
 zlong_alert_pre() {
     zlong_last_cmd=$1
 
-    if [[ $zlong_ignorespace == 'true' && ${zlong_last_cmd:0:1} == ' ' ]]; then
+    if [[ $zlong_ignorespace == 'true' && ${zlong_last_cmd:0:1} == [[:space:]] ]]; then
         # set internal variables to nothing ignoring this command
         zlong_last_cmd=''
         zlong_timestamp=0

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -16,6 +16,9 @@ fi
 # Set commands to ignore if needed
 (( ${+zlong_ignore_cmds} )) || zlong_ignore_cmds='vim ssh'
 
+# Set as true to ignore commands starting with a space
+(( ${+zlong_ignorespace} )) || zlong_ignorespace='false'
+
 
 # Need to set an initial timestamps otherwise, we'll be comparing an empty
 # string with an integer.
@@ -33,8 +36,18 @@ zlong_alert_func() {
 }
 
 zlong_alert_pre() {
-    zlong_timestamp=$EPOCHSECONDS
     zlong_last_cmd=$1
+
+    if [[ $zlong_ignorespace == 'true' && ${zlong_last_cmd:0:1} == ' ' ]]; then
+        # set internal variables to nothing ignoring this command
+        zlong_last_cmd=''
+        zlong_timestamp=0
+    else
+        # clean up white space so the notify output is nice
+        zlong_last_cmd="$(echo "$1" | sed -e 's|^\s\+||' -e 's|\s\s\+|\s|')"
+        zlong_timestamp=$EPOCHSECONDS
+    fi
+
 }
 
 zlong_alert_post() {


### PR DESCRIPTION
zlong_alert will now alert for commands that start with a blank white space and an option to ignore those commands
