### PR TITLE
add script directory to plugin file

### DIFF
--- a/zlong_alert.plugin.zsh
+++ b/zlong_alert.plugin.zsh
@@ -1,7 +1,9 @@
 # Based on the Zsh Plugin Standard.
 # https://zdharma.org/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
 
+# make sure the get the full path to this file
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
 
-eval "$(<zlong_alert.zsh)"
+# open the given file in to a string then evaluate the string in this shell
+eval "$(< "${0:h}/zlong_alert.zsh")"


### PR DESCRIPTION
this file makes sure the file path is not relative by
adjusting the `$0` variable then eval's the actual plugin,
since the `$0` variable corresponds to the current file path not the actual
plugin file the `${var:h}` zsh expansion is used to get just the directory name