### PR TITLE
Add support for MacOS notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # zlong_alert.zsh
 
-`zlong_alert.zsh` will use `notify-send` and a
+`zlong_alert.zsh` will send a desktop notification and sound a
 [bell](https://en.wikipedia.org/wiki/Bell_character) to alert you when a
 command that has taken a long time (default: 15 seconds) has completed.
+
+Desktop notifications are sent using `notify-send` on Linux and using [`alerter`](https://github.com/vjeantet/alerter) on MacOS.
 
 ---
 
 ## Installation
+
+### Pre-requisite for MacOS only
+
+Ensure that you downloaded the alerter binary from [here](https://github.com/vjeantet/alerter/releases), have placed it in your PATH, and given the file executable permissions before continuing with any of the installation methods.
 
 ### zplug
 

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ There are 4 variables you can set that will alter the behavior this script.
 
 - `zlong_duration` (default: `15`): number of seconds that is considered a long duration.
 - `zlong_ignore_cmds` (default: `"vim ssh"`): commands to ignore.
-- `zlong_use_notify_send` (default: `true`): whether to use `notify-send`.
+- `zlong_send_notifications` (default: `true`): whether to send notifications.
 - `zlong_ignorespace` (default: `false`): whether to ignore commands with a leading space
 
 For example, adding the following anywhere in your `.zshrc`
 ```bash
-zlong_use_notify_send=false
+zlong_send_notifications=false
 zlong_duration=2
 zlong_ignore_cmds="vim ssh pacman yay"
 ```
-will alert you, without using `notify-send`, if a command has lasted for more
+will alert you, without sending a notification, if a command has lasted for more
 than 2 seconds, provided that the command does not start with any of `vim ssh
 pacman yay`.
 

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -4,9 +4,15 @@ zmodload zsh/datetime || return
 # Be sure we can actually set hooks
 autoload -Uz add-zsh-hook || return
 
+# Use value of zlong_use_notify_send if defined
+(( ${+zlong_use_notify_send} )) && zlong_internal_send_notifications=$zlong_use_notify_send
+
+# Use value of zlong_send_notifications if defined - This takes precedence over zlong_use_notify_send
+(( ${+zlong_send_notifications} )) && zlong_internal_send_notifications=$zlong_send_notifications
+
 # Disable notifications if both alerter and notify-send don't exist
 if ! ([[ -x "$(command -v notify-send)" ]] || [[ -x "$(command -v alerter)" ]]); then
-    zlong_send_notifications='false'
+    zlong_internal_send_notifications='false'
 fi
 
 # Define a long duration if needed
@@ -29,7 +35,7 @@ zlong_alert_func() {
     local secs=$2
     local ftime=$(printf '%dh:%dm:%ds\n' $(($secs / 3600)) $(($secs % 3600 / 60)) $(($secs % 60)))
     local message="Done: $1 Time: $ftime"
-    if [[ "$zlong_send_notifications" != false ]]; then
+    if [[ "$zlong_internal_send_notifications" != false ]]; then
         # Find and use the correct notification command based on OS name
         if [[ "${uname}" == "Linux" ]]
         then

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -37,10 +37,9 @@ zlong_alert_func() {
     local message="Done: $1 Time: $ftime"
     if [[ "$zlong_internal_send_notifications" != false ]]; then
         # Find and use the correct notification command based on OS name
-        if [[ "${uname}" == "Linux" ]]
-        then
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
             notify-send $message
-        else
+        elif [[ "$OSTYPE" == "darwin"* ]]; then
             (alerter -timeout 3 -message $message &>/dev/null &)
         fi
     fi

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -6,7 +6,7 @@ autoload -Uz add-zsh-hook || return
 
 # Disable notifications if both alerter and notify-send don't exist
 if ! ([[ -x "$(command -v notify-send)" ]] || [[ -x "$(command -v alerter)" ]]); then
-    zlong_use_notify_send='false'
+    zlong_send_notifications='false'
 fi
 
 # Define a long duration if needed
@@ -29,7 +29,7 @@ zlong_alert_func() {
     local secs=$2
     local ftime=$(printf '%dh:%dm:%ds\n' $(($secs / 3600)) $(($secs % 3600 / 60)) $(($secs % 60)))
     local message="Done: $1 Time: $ftime"
-    if [[ "$zlong_use_notify_send" != false ]]; then
+    if [[ "$zlong_send_notifications" != false ]]; then
         # Find and use the correct notification command based on OS name
         if [[ "${uname}" == "Linux" ]]
         then

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -4,12 +4,6 @@ zmodload zsh/datetime || return
 # Be sure we can actually set hooks
 autoload -Uz add-zsh-hook || return
 
-# Use notify-send if it exists and is not explicitly disabled
-if ! [[ -x "$(command -v notify-send)" ]]; then
-    zlong_use_notify_send='false'
-fi
-(( ${+zlong_use_notify_send} )) || zlong_use_notify_send='true'
-
 # Define a long duration if needed
 (( ${+zlong_duration} )) || zlong_duration=15
 
@@ -29,8 +23,15 @@ zlong_alert_func() {
     local cmd=$1
     local secs=$2
     local ftime=$(printf '%dh:%dm:%ds\n' $(($secs / 3600)) $(($secs % 3600 / 60)) $(($secs % 60)))
-    if [[ "$zlong_use_notify_send" == true ]]; then
-        notify-send "Done: $1" "Time: $ftime"
+    local message="Done: $1 Time: $ftime"
+    if [[ "$zlong_use_notify_send" != false ]]; then
+        # Find and use the correct notification command based on OS name
+        if [[ "${uname}" == "Linux" ]]
+        then
+            notify-send $message
+        else
+            (alerter -timeout 3 -message $message &>/dev/null &)
+        fi
     fi
     echo -n "\a"
 }

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -4,6 +4,11 @@ zmodload zsh/datetime || return
 # Be sure we can actually set hooks
 autoload -Uz add-zsh-hook || return
 
+# Disable notifications if both alerter and notify-send don't exist
+if ! ([[ -x "$(command -v notify-send)" ]] || [[ -x "$(command -v alerter)" ]]); then
+    zlong_use_notify_send='false'
+fi
+
 # Define a long duration if needed
 (( ${+zlong_duration} )) || zlong_duration=15
 


### PR DESCRIPTION
Implemented changes to support notifications on MacOS as per discussions on #8 

Note: I didn't update the version number or mark zlong_use_notify_send as deprecated in the README, decided to leave both changes up to the maintainer. If you would prefer that I make those changes in the PR, let me know and I'll update accordingly.