### PR TITLE
FIx "Invalid number of options."

### DIFF
--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -38,7 +38,7 @@ zlong_alert_func() {
     if [[ "$zlong_internal_send_notifications" != false ]]; then
         # Find and use the correct notification command based on OS name
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-            notify-send $message
+            notify-send "$message"
         elif [[ "$OSTYPE" == "darwin"* ]]; then
             (alerter -timeout 3 -message $message &>/dev/null &)
         fi


### PR DESCRIPTION
On linux (fedora 36) I get "Invalid number of options." error. Putting $message in double quotes fixes it.