### PR TITLE
Optimize zlong_ignore_cmds handling & add Zim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ zplug "kevinywlui/zlong_alert.zsh"
 
 ### Zim
 
-In file ~/.zimrc, add :
+Add in your `~/.zimrc`:
 ```bash
 zmodule "kevinywlui/zlong_alert.zsh" --source zlong_alert.zsh
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ zplug "kevinywlui/zlong_alert.zsh"
 
 Add in your `~/.zimrc`:
 ```bash
-zmodule "kevinywlui/zlong_alert.zsh" --source zlong_alert.zsh
+zmodule "kevinywlui/zlong_alert.zsh" --name zlong_alert
 ```
 
 ### Manual 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ zplug "kevinywlui/zlong_alert.zsh"
 1. Clone into `$ZSH_CUSTOM/plugins/zlong_alert`.
 2. Add `zlong_alert` to `plugins` in `.zshrc`.
 
+### Zim
+
+In file ~/.zimrc, add :
+```bash
+zmodule "kevinywlui/zlong_alert.zsh" --source zlong_alert.zsh
+```
+
 ### Manual 
 
 This script just needs to be sourced so add this to your `.zshrc`:

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -58,6 +58,10 @@ zlong_alert_pre() {
         zlong_timestamp=$EPOCHSECONDS
     fi
 
+    # Remove leading space(s), not useful anymore
+    while [[ ${zlong_last_cmd:0:1} == [[:space:]] ]]; do
+	zlong_last_cmd="${zlong_last_cmd:1}"
+    done
 }
 
 zlong_alert_post() {

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -64,8 +64,8 @@ zlong_alert_post() {
     local duration=$(($EPOCHSECONDS - $zlong_timestamp))
     local lasted_long=$(($duration - $zlong_duration))
     local cmd_head="${zlong_last_cmd/ */}"
-    if [[ $lasted_long -gt 0 && ! -z $zlong_last_cmd && ! $zlong_ignore_cmds =~ (^|[[:space:]])${cmd_head}([[:space:]]|$) ]]; then
-        zlong_alert_func $zlong_last_cmd duration
+    if [[ $lasted_long -gt 0 && ! -z $zlong_last_cmd && ! "$zlong_ignore_cmds" =~ (^|[[:space:]])${cmd_head}([[:space:]]|$) ]]; then
+        zlong_alert_func "$zlong_last_cmd" duration
     fi
     zlong_last_cmd=''
 }

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -63,8 +63,8 @@ zlong_alert_pre() {
 zlong_alert_post() {
     local duration=$(($EPOCHSECONDS - $zlong_timestamp))
     local lasted_long=$(($duration - $zlong_duration))
-    local cmd_head=$(echo "$zlong_last_cmd" | awk '{printf $1}')
-    if [[ $lasted_long -gt 0 && ! -z $zlong_last_cmd && ! $zlong_ignore_cmds =~ $cmd_head ]]; then
+    local cmd_head="${zlong_last_cmd/ */}"
+    if [[ $lasted_long -gt 0 && ! -z $zlong_last_cmd && ! $zlong_ignore_cmds =~ (^|[[:space:]])${cmd_head}([[:space:]]|$) ]]; then
         zlong_alert_func $zlong_last_cmd duration
     fi
     zlong_last_cmd=''

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -63,7 +63,7 @@ zlong_alert_pre() {
 zlong_alert_post() {
     local duration=$(($EPOCHSECONDS - $zlong_timestamp))
     local lasted_long=$(($duration - $zlong_duration))
-    local cmd_head="${zlong_last_cmd/ */}"
+    local cmd_head="${zlong_last_cmd%% *}"
     if [[ $lasted_long -gt 0 && ! -z $zlong_last_cmd && ! "$zlong_ignore_cmds" =~ (^|[[:space:]])${cmd_head}([[:space:]]|$) ]]; then
         zlong_alert_func "$zlong_last_cmd" duration
     fi


### PR DESCRIPTION
- Replace awk call by variable substitution (reduce external command calls)
- zlong_ignore_cmds precisely checks (e.g.: do not consider "zless" if you only asked to ignore "less"); do not consider "vim" if you only asked to ignore "vi")
- Add Zim frameword in the README