### PR TITLE
Disable sound bell

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ There are 4 variables you can set that will alter the behavior this script.
 - `zlong_duration` (default: `15`): number of seconds that is considered a long duration.
 - `zlong_ignore_cmds` (default: `"vim ssh"`): commands to ignore.
 - `zlong_send_notifications` (default: `true`): whether to send notifications.
+- `zlong_terminal_bell` (default: `true`): whether to enable the terminal bell.
 - `zlong_ignorespace` (default: `false`): whether to ignore commands with a leading space
 - `zlong_message` (default: `'"Done: $cmd Time: $ftime"'`): define a custom message to display
 

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -15,6 +15,9 @@ if ! ([[ -x "$(command -v notify-send)" ]] || [[ -x "$(command -v alerter)" ]]);
     zlong_internal_send_notifications='false'
 fi
 
+# Set as true to enable terminal bell (beep)
+(( ${+zlong_terminal_bell} )) || zlong_terminal_bell='true'
+
 # Define a long duration if needed
 (( ${+zlong_duration} )) || zlong_duration=15
 
@@ -44,7 +47,10 @@ zlong_alert_func() {
             (alerter -timeout 3 -message $zlong_message &>/dev/null &)
         fi
     fi
-    echo -n "\a"
+
+    if [[ "$zlong_terminal_bell" == 'true' ]]; then
+	echo -n "\a"
+    fi
 }
 
 zlong_alert_pre() {


### PR DESCRIPTION
Hi,

This enhancement allow the user to disable the bell (not needed if the desktop already generate a sound notification), using new variable $zlong_terminal_bell.
Do not hesitate to change the name/description of this variable.
