### PR TITLE
Add feature Ignore prefix (like sudo or time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ source /path/to/zlong_alert.zsh
 
 ## Configuration
 
-There are 4 variables you can set that will alter the behavior this script.
+There are 7 variables you can set that will alter the behavior this script.
 
 - `zlong_duration` (default: `15`): number of seconds that is considered a long duration.
-- `zlong_ignore_cmds` (default: `"vim ssh"`): commands to ignore.
+- `zlong_ignore_cmds` (default: `"vim ssh"`): commands to ignore (no not notify).
+- `zlong_ignore_pfxs` (default: `"sudo time"`): prefixes to ignore (consider command in argument).
 - `zlong_send_notifications` (default: `true`): whether to send notifications.
 - `zlong_terminal_bell` (default: `true`): whether to enable the terminal bell.
 - `zlong_ignorespace` (default: `false`): whether to ignore commands with a leading space

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ source /path/to/zlong_alert.zsh
 There are 7 variables you can set that will alter the behavior this script.
 
 - `zlong_duration` (default: `15`): number of seconds that is considered a long duration.
-- `zlong_ignore_cmds` (default: `"vim ssh"`): commands to ignore (no not notify).
+- `zlong_ignore_cmds` (default: `"vim ssh"`): commands to ignore (do not notify).
 - `zlong_ignore_pfxs` (default: `"sudo time"`): prefixes to ignore (consider command in argument).
 - `zlong_send_notifications` (default: `true`): whether to send notifications.
 - `zlong_terminal_bell` (default: `true`): whether to enable the terminal bell.

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -80,19 +80,19 @@ zlong_alert_post() {
 
     # Ignore command prefixes (like time and sudo)
     # and then consider command in argument
-    local zlong_last_cmd_no_pfx="$zlong_last_cmd"
+    local last_cmd_no_pfx="$zlong_last_cmd"
     local no_pfx
-    while [[ -n "$zlong_last_cmd_no_pfx" && -z "$no_pfx" ]]; do
- 	cmd_head="${zlong_last_cmd_no_pfx%% *}"
+    while [[ -n "$last_cmd_no_pfx" && -z "$no_pfx" ]]; do
+ 	cmd_head="${last_cmd_no_pfx%% *}"
 	if [[ $zlong_ignore_pfxs =~ (^|[[:space:]])${cmd_head}([[:space:]]|$) ]]; then
-	    zlong_last_cmd_no_pfx="${zlong_last_cmd_no_pfx#* }"
+	    last_cmd_no_pfx="${last_cmd_no_pfx#* }"
 	else
 	    no_pfx=true
 	fi
     done
 
     # Notify only if delay > $zlong_duration and command not ignored
-    if [[ $lasted_long -gt 0 && ! -z $zlong_last_cmd_no_pfx && ! "$zlong_ignore_cmds" =~ (^|[[:space:]])${cmd_head}([[:space:]]|$) ]]; then
+    if [[ $lasted_long -gt 0 && ! -z $last_cmd_no_pfx && ! "$zlong_ignore_cmds" =~ (^|[[:space:]])${cmd_head}([[:space:]]|$) ]]; then
         zlong_alert_func "$zlong_last_cmd" duration
     fi
     zlong_last_cmd=''

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -21,10 +21,10 @@ fi
 # Define a long duration if needed
 (( ${+zlong_duration} )) || zlong_duration=15
 
-# Set commands to ignore if needed
+# Set commands to ignore (do not notify) if needed
 (( ${+zlong_ignore_cmds} )) || zlong_ignore_cmds='vim ssh'
 
-# Set prefixes to ignore if needed
+# Set prefixes to ignore (consider command in argument) if needed
 (( ${+zlong_ignore_pfxs} )) || zlong_ignore_pfxs='sudo time'
 
 # Set as true to ignore commands starting with a space


### PR DESCRIPTION
Hi,

My last branch currently in the pipeline !

This feature ignore "prefixes" like "sudo" or "time" (defined in variable $zlong_ignore_pfxs).

If any of these prefixes (or both of them) are used, then the plugin check the command called as 1st argument.

Typically :

```bash
> time sudo sleep 12
```
=> will send a notification

```bash
> time sudo vim ~/.zshrc
```
=> will not send a notification (since "vim" is in $zlong_ignore_cmds)

If `zlong_ignorespace='true'`, then

```bash
>   time sudo sleep 12
```
=> will not send a notification

I'm not entirely convinced by the name "prefix" used here. So do not hesitate if you have a better naming.

