### PR TITLE
Fix failed to compile regex error

### DIFF
--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -84,7 +84,7 @@ zlong_alert_post() {
     local no_pfx
     while [[ -n "$last_cmd_no_pfx" && -z "$no_pfx" ]]; do
  	cmd_head="${last_cmd_no_pfx%% *}"
-	if [[ $zlong_ignore_pfxs =~ (^|[[:space:]])${cmd_head}([[:space:]]|$) ]]; then
+	if [[ $zlong_ignore_pfxs =~ (^|[[:space:]])${(q)cmd_head}([[:space:]]|$) ]]; then
 	    last_cmd_no_pfx="${last_cmd_no_pfx#* }"
 	else
 	    no_pfx=true
@@ -92,7 +92,7 @@ zlong_alert_post() {
     done
 
     # Notify only if delay > $zlong_duration and command not ignored
-    if [[ $lasted_long -gt 0 && ! -z $last_cmd_no_pfx && ! "$zlong_ignore_cmds" =~ (^|[[:space:]])${cmd_head}([[:space:]]|$) ]]; then
+    if [[ $lasted_long -gt 0 && ! -z $last_cmd_no_pfx && ! "$zlong_ignore_cmds" =~ (^|[[:space:]])${(q)cmd_head}([[:space:]]|$) ]]; then
         zlong_alert_func "$zlong_last_cmd" duration
     fi
     zlong_last_cmd=''


### PR DESCRIPTION
This PR fixes this kind of issue :

```bash
> test2="${test%% *}"
zlong_alert_post:10: failed to compile regex: Invalid preceding regular expression
```

By escaping special characters in variable $cmd_head by using Parameter Expansion Flags "(q)"
