### PR TITLE
Silence stderr from notify-send

### DIFF
--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -41,7 +41,7 @@ zlong_alert_func() {
     if [[ "$zlong_internal_send_notifications" != false ]]; then
         # Find and use the correct notification command based on OS name
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	    eval notify-send $zlong_message
+	    eval notify-send $zlong_message 2>/dev/null
         elif [[ "$OSTYPE" == "darwin"* ]]; then
             (alerter -timeout 3 -message $zlong_message &>/dev/null &)
         fi


### PR DESCRIPTION
On (some) systems that have `notify-send`, but aren't currently running a graphical environment, `notify-send` can emit output to stderr:

```
➜ sleep 16
GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
```

This change direct `notify-send`'s stderr to /dev/null to avoid emitting the confusing output.