### PR TITLE
pass a function instead of a formatting message

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ There are 7 variables you can set that will alter the behavior this script.
 - `zlong_send_notifications` (default: `true`): whether to send notifications.
 - `zlong_terminal_bell` (default: `true`): whether to enable the terminal bell.
 - `zlong_ignorespace` (default: `false`): whether to ignore commands with a leading space
-- `zlong_message` (default: `'"Done: $cmd Time: $ftime"'`): define a custom message to display
+- `zlong_message` (default: `'"Done: $cmd Time: $ftime with status $cmd_status"'`): define a custom message to display
 
 For example, adding the following anywhere in your `.zshrc`
 ```bash
@@ -75,7 +75,7 @@ pacman yay`.
 `zlong_message` requires very specific syntax in order to function correctly.
 Arguments passed must be wrapped in single quotes and then doubles quotes in order
 for the variables to be passed in correctly to the evaluation function. Currently,
-the variables `$cmd` and `$ftime` are available to be included in your `zlong_message`
+the variables `$cmd`, `$cmd_status` and `$ftime` are available to be included in your `zlong_message`
 definition. Some notification clients (i.e. notify-send) allow both a heading and
 a body message to be passed. Examples of how to do so are below:
 

--- a/zlong_alert.zsh
+++ b/zlong_alert.zsh
@@ -34,24 +34,24 @@ fi
 (( ${+zlong_message} )) || zlong_message='"Done: $cmd Time: $ftime with status $cmd_status"'
 
 # Define the alerting function, do the text processing here
-zlong_alert_func() {
+zlong_alert_func_default() {
     local cmd="$1"
     local secs="$2"
     local cmd_status="$3"
-    local ftime="$(printf '%dh:%dm:%ds\n' $(($secs / 3600)) $(($secs % 3600 / 60)) $(($secs % 60)))"
+    local ftime="$(zlong_alert_display_duration $secs)"
     if [[ "$zlong_internal_send_notifications" != false ]]; then
         # Find and use the correct notification command based on OS name
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-            eval notify-send $zlong_message
+            eval notify-send $zlong_title $zlong_message
         elif [[ "$OSTYPE" == "darwin"* ]]; then
             (alerter -timeout 3 -message $zlong_message &>/dev/null &)
         fi
     fi
 
-    if [[ "$zlong_terminal_bell" == 'true' ]]; then
-	echo -n "\a"
-    fi
 }
+
+(( ${+zlong_alert_func} )) || zlong_alert_func_default
+
 
 zlong_alert_pre() {
     zlong_last_cmd="$1"
@@ -86,6 +86,10 @@ zlong_alert_post() {
     # Notify only if delay > $zlong_duration and command not ignored
     if [[ $lasted_long -gt 0 && ! -z $last_cmd_no_pfx && ! "$zlong_ignore_cmds" =~ "(^|[[:space:]])${(q)cmd_head}([[:space:]]|$)" ]]; then
         zlong_alert_func "$zlong_last_cmd" "$duration" "$cmd_exit_status"
+
+        if [[ "$zlong_terminal_bell" == 'true' ]]; then
+            echo -n "\a"
+        fi
     fi
     zlong_last_cmd=''
 }


### PR DESCRIPTION

this builds on my previous PR but it's just a draft to show that passing a
function would be more powerful than just a message.

1/ Starting point is that I didn't like the formatting of duration and it's
currently not possible to override this
2/ I wanted to display the command as the content of the notification since my
notification manager trims the title

